### PR TITLE
Fix "Crop already exists"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: php
 
 php:
   - 7.0
+  env: PHPUNIT5=true
   - 7.1
+  env: PHPUNIT5=true
   - 7.2
 
 before_script:
   - composer install --dev
+  - if [[ $PHPUNIT5 == true ]]; then composer require --dev "phpunit/phpunit:^5.0"; fi
   - yarn add mocha
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ language: php
 matrix:
   include:
     - php: 7.0
-      env: PHPUNIT5=true
+      env: PHPUNIT6=true
     - php: 7.1
-      env: PHPUNIT5=true
+      env: PHPUNIT7=true
     - php: 7.2
 
 before_script:
   - composer install --dev
-  - if [[ $PHPUNIT5 == true ]]; then composer require --dev "phpunit/phpunit:^5.0"; fi
+  - if [[ $PHPUNIT6 == true ]]; then composer require --dev "phpunit/phpunit:^6.0"; fi
+  - if [[ $PHPUNIT7 == true ]]; then composer require --dev "phpunit/phpunit:^7.0"; fi
   - yarn add mocha
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: php
 
-php:
-  - 7.0
-  env: PHPUNIT5=true
-  - 7.1
-  env: PHPUNIT5=true
-  - 7.2
+matrix:
+  include:
+    - php: 7.0
+      env: PHPUNIT5=true
+    - php: 7.1
+      env: PHPUNIT5=true
+    - php: 7.2
 
 before_script:
   - composer install --dev

--- a/src/Bkwld/Croppa/Storage.php
+++ b/src/Bkwld/Croppa/Storage.php
@@ -181,9 +181,7 @@ class Storage {
         try {
             $this->getCropsDisk()->write($path, $contents);
         } catch(FileExistsException $e) {
-            throw new Exception("Croppa: Crop already exists at $path. You probably
-                have a misconfiguration. Make sure that the URL to your crop can be
-                transformed by the `path` config to your `crop_dir`.");
+            // don't throw exception anymore as mentioned in PR #164 
         }
 
     }


### PR DESCRIPTION
From stefnats/croppa:

> As mentioned by @weotch discussed with me in PR BKWLD#164
> "lets say you had a page with the same image with the same crops rendered on it 5 times. On an initial request of this page, the crop would not exist. Lets say there were 5 http server threads handling these requests. If the requests all hit at the same time, all 5 would try to generate the image and save it to disk. One of them would finish first and then the other 4 would throw Crop already exists exceptions. I feel like this is a valid use case and IS a reason that I should make this condition not fatally error. It should just silently return the image response.
> 
> However, I think the fix should be a change to writeCrop where it just returns rather than throwing an Exception."
